### PR TITLE
Fix cleanup import issue

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from utils.cut_video import cut_video_with_smart_frame  # Importando a função 
 from dotenv import load_dotenv
 import threading
 import logging
+import shutil
 import moviepy.editor as mp
 from utils.file_manager import FileManager
 from threading import Lock


### PR DESCRIPTION
## Summary
- fix missing `shutil` import used for cleanup

## Testing
- `python -m py_compile app.py utils/*.py models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc5383e20833182cde1a7b10db9ec