### PR TITLE
Fix missing import in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import time
 import json
+import shutil
 from flask import Flask, request, render_template, send_from_directory, jsonify, session, redirect, url_for
 from utils.download_video import download_video
 from utils.extract_audio import extract_audio


### PR DESCRIPTION
## Summary
- include missing `shutil` import for cleanup routine

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fc51a49d48331982e5cfe8e9845ac